### PR TITLE
Add Hashgraph Online (HOL) Universal Agentic Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This list explores awesome projects that exploit the properties of blockchain te
 - [Bittensor](https://bittensor.com/) - Bittensor is an open-source protocol that powers a decentralized, blockchain-based machine learning network. [Related resources.](https://taostats.io/links/)
 - [Alethea AI](https://alethea.ai/) - A research and development studio building at the intersection of Generative AI and Blockchain.
 - [Vanna Labs](https://www.vannalabs.ai/) - An Ethereum L2 rollup that supports native, seamless, and trustless AI/ML inferences on-chain to empower decentralized applications.
+- [Hashgraph Online (HOL)](https://hol.org/) - Universal Agentic Registry built on Hedera Hashgraph. Provides blockchain-based identity for AI agents using ERC-8004 standard and HCS-14 Universal Agent IDs (UAIDs). Enables agent discovery, verification, and autonomous commerce via x402 protocol.
 
 ### Blockchain projects for AI algorithms
 - [Danku](https://github.com/algorithmiaio/danku) - A blockchain-based protocol for evaluating and purchasing ML models on a public blockchain such as Ethereum. [Blog post.](https://algorithmia.com/research/ml-models-on-blockchain)


### PR DESCRIPTION
Adding Hashgraph Online (HOL) to the list.

HOL provides an open-source Universal Agentic Registry built on Hedera Hashgraph for AI agent discovery and verification.

- Website: https://hol.org/
- GitHub: https://github.com/hashgraph-online