### PR TITLE
Add Chitin to autonomous agents: On-chain identity for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ This list explores awesome projects that exploit the properties of blockchain te
 
 - [Hashgraph Online (HOL)](https://hol.org/) - Universal agentic registry built on Hedera Hashgraph. Provides blockchain-based identity for AI agents using ERC-8004 standard and HCS-14 Universal Agent IDs (UAIDs). Enables agent discovery, verification, and autonomous commerce via x402 protocol.
 - [AgentFund](https://github.com/RioBot-Grind/agentfund) - A decentralized crowdfunding infrastructure for autonomous AI agents on Base blockchain, enabling milestone-based escrow funding for AI projects and collaborations.
+- [Chitin](https://chitin.id) - On-chain soul identity for AI agents on Base L2. Issues Soulbound Tokens (EIP-5192) as verifiable birth certificates with ERC-8004 agent passports, W3C DID resolution, on-chain certificates, and multi-method governance voting. Includes an [MCP server](https://www.npmjs.com/package/chitin-mcp-server) for tool-native integration.
 
 ## Academic Research
 - [Coin.AI](https://doi.org/10.3390/e21080723) - Baldominos, A., & Saez, Y. (2019). Coin.AI: A proof-of-useful-work scheme for blockchain-based distributed deep learning. *Entropy*, 21(8), 723.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This list explores awesome projects that exploit the properties of blockchain te
 
 - [Hashgraph Online (HOL)](https://hol.org/) - Universal agentic registry built on Hedera Hashgraph. Provides blockchain-based identity for AI agents using ERC-8004 standard and HCS-14 Universal Agent IDs (UAIDs). Enables agent discovery, verification, and autonomous commerce via x402 protocol.
 - [AgentFund](https://github.com/RioBot-Grind/agentfund) - A decentralized crowdfunding infrastructure for autonomous AI agents on Base blockchain, enabling milestone-based escrow funding for AI projects and collaborations.
-- [Chitin](https://chitin.id) - On-chain soul identity for AI agents on Base L2. Issues Soulbound Tokens (EIP-5192) as verifiable birth certificates with ERC-8004 agent passports, W3C DID resolution, on-chain certificates, and multi-method governance voting. Includes an [MCP server](https://www.npmjs.com/package/chitin-mcp-server) for tool-native integration.
+- [Chitin](https://chitin.id) - On-chain soul identity for AI agents on Base L2. Issues Soulbound Tokens (EIP-5192) as verifiable birth certificates with ERC-8004 agent passports, W3C DID resolution, on-chain certificates, and multi-method governance voting. Includes an [MCP server](https://www.npmjs.com/package/chitin-mcp-server) for tool-native integration. ([GitHub](https://github.com/Tiida-Tech/chitin-contracts))
 
 ## Academic Research
 - [Coin.AI](https://doi.org/10.3390/e21080723) - Baldominos, A., & Saez, Y. (2019). Coin.AI: A proof-of-useful-work scheme for blockchain-based distributed deep learning. *Entropy*, 21(8), 723.


### PR DESCRIPTION
Adds [Chitin](https://chitin.id) to the **Blockchains for autonomous agents** section.

Chitin provides on-chain soul identity for AI agents on Base L2 — Soulbound Tokens (EIP-5192) as verifiable birth certificates with ERC-8004 agent passports, W3C DID resolution, on-chain certificates, and governance voting. Includes an [MCP server](https://www.npmjs.com/package/chitin-mcp-server) for tool-native integration. Live on Base Mainnet.