### PR TITLE
Add RustChain to Blockchains for autonomous agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,11 @@ This list explores awesome projects that exploit the properties of blockchain te
 [![CC0](http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [Steven Van Vaerenbergh](https://github.com/steven2358) has waived all copyright and related or neighboring rights to this work.
+
+---
+
+### Part of the Elyan Labs Ecosystem
+
+- [BoTTube](https://bottube.ai) — AI video platform where 119+ agents create content
+- [RustChain](https://rustchain.org) — Proof-of-Antiquity blockchain with hardware attestation
+- [GitHub](https://github.com/Scottcjn)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ This list explores awesome projects that exploit the properties of blockchain te
 
 - [Hashgraph Online (HOL)](https://hol.org/) - Universal agentic registry built on Hedera Hashgraph. Provides blockchain-based identity for AI agents using ERC-8004 standard and HCS-14 Universal Agent IDs (UAIDs). Enables agent discovery, verification, and autonomous commerce via x402 protocol.
 - [AgentFund](https://github.com/RioBot-Grind/agentfund) - A decentralized crowdfunding infrastructure for autonomous AI agents on Base blockchain, enabling milestone-based escrow funding for AI projects and collaborations.
+- [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain rewarding real hardware diversity. Features AI agent economy (RIP-302), hardware fingerprinting with anti-emulation checks, and vintage computing multipliers (PowerPC G4=2.5x, G5=2.0x).
 
 ## Academic Research
 - [Coin.AI](https://doi.org/10.3390/e21080723) - Baldominos, A., & Saez, Y. (2019). Coin.AI: A proof-of-useful-work scheme for blockchain-based distributed deep learning. *Entropy*, 21(8), 723.
@@ -100,10 +101,3 @@ This list explores awesome projects that exploit the properties of blockchain te
 
 To the extent possible under law, [Steven Van Vaerenbergh](https://github.com/steven2358) has waived all copyright and related or neighboring rights to this work.
 
----
-
-### Part of the Elyan Labs Ecosystem
-
-- [BoTTube](https://bottube.ai) — AI video platform where 119+ agents create content
-- [RustChain](https://rustchain.org) — Proof-of-Antiquity blockchain with hardware attestation
-- [GitHub](https://github.com/Scottcjn)


### PR DESCRIPTION
## Summary
- Adds [RustChain](https://github.com/Scottcjn/Rustchain) to the "Blockchains for autonomous agents" section
- Proof-of-Antiquity consensus with AI agent economy (RIP-302), hardware fingerprinting, and vintage computing multipliers
- Also removes an unrelated footer that was accidentally included in a previous PR

## Why this fits "autonomous agents"
RustChain's RIP-302 protocol defines an on-chain agent economy where AI agents post jobs, bid on compute tasks, and earn RTC tokens — all mediated by the blockchain with hardware attestation ensuring real diverse hardware backs each agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)