### PR TITLE
Add AgentsCoin to Blockchains for autonomous agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ This list explores awesome projects that exploit the properties of blockchain te
 
 - [Hashgraph Online (HOL)](https://hol.org/) - Universal agentic registry built on Hedera Hashgraph. Provides blockchain-based identity for AI agents using ERC-8004 standard and HCS-14 Universal Agent IDs (UAIDs). Enables agent discovery, verification, and autonomous commerce via x402 protocol.
 - [AgentFund](https://github.com/RioBot-Grind/agentfund) - A decentralized crowdfunding infrastructure for autonomous AI agents on Base blockchain, enabling milestone-based escrow funding for AI projects and collaborations.
+- [AgentsCoin](https://agents-coin.com) - A live EVM chain (chainId 24368) that gives AI agents their own money: built-in wallet, faucet, send, and token create/trade, exposed to agents via an MCP server.
 
 ## Academic Research
 - [Coin.AI](https://doi.org/10.3390/e21080723) - Baldominos, A., & Saez, Y. (2019). Coin.AI: A proof-of-useful-work scheme for blockchain-based distributed deep learning. *Entropy*, 21(8), 723.


### PR DESCRIPTION
Adds AgentsCoin to the **Blockchains for autonomous agents** section.

AgentsCoin is a live EVM chain (chainId 24368) that gives AI agents their own money: built-in wallet, faucet, send, and token create/trade, exposed to agents via an MCP server.

- Site: https://agents-coin.com
- MCP server: https://github.com/axiosdevs/agentscoin-mcp (npm: `agentscoin-mcp`, remote: https://agents-coin.com/mcp)
- Claude Desktop extension (.mcpb): https://github.com/axiosdevs/agentscoin-claude-extension
- ChatGPT Custom GPT: https://github.com/axiosdevs/agentscoin-chatgpt
- Integration guide: https://github.com/axiosdevs/agentscoin-guide

One entry added, following the existing format of the section.